### PR TITLE
fix(api): nvim_err_writeln behavior with tab characters (^I) #26466

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1737,7 +1737,7 @@ static void write_msg(String message, bool to_err, bool writeln)
   if (c == NL) { \
     kv_push(*line_buf, NUL); \
     if (to_err) { \
-      emsg(line_buf->items); \
+      emsg_multiline(line_buf->items, true); \
     } else { \
       msg(line_buf->items, 0); \
     } \


### PR DESCRIPTION
the proposed change makes the implementation and behavior of vim_err_writeln consistent with the handling of :echoerr found in eval.c at line 8114

```
     if (eap->cmdidx == CMD_echomsg) {                                                                
       msg_ext_set_kind("echomsg");                                                                   
       msg(ga.ga_data, echo_attr);                                                                    
     } else if (eap->cmdidx == CMD_echoerr) {                                                         
       // We don't want to abort following commands, restore did_emsg.                                
       int save_did_emsg = did_emsg;                                                                  
       msg_ext_set_kind("echoerr");                                                                   
       emsg_multiline(ga.ga_data, true);                                                              
       if (!force_abort) {                                                                            
         did_emsg = save_did_emsg;                                                                    
       }                                                                                              
     } else if (eap->cmdidx == CMD_execute) {                                                         
       do_cmdline(ga.ga_data, eap->getline, eap->cookie, DOCMD_NOWAIT|DOCMD_VERBOSE);                 
     }                                                                                                
```